### PR TITLE
Support daylight saving time

### DIFF
--- a/Dateien zu Teil 2/SolarwetterV2.ino
+++ b/Dateien zu Teil 2/SolarwetterV2.ino
@@ -11,8 +11,8 @@
 const char *SSID = "MakeMesse";
 const char *PWD = "DiDumDiDei";
 const char* ntpServer = "pool.ntp.org";
-const long  gmtOffset_sec = 3600;
-const int   daylightOffset_sec = 3600;
+const char *timeZone = "CET-1CEST,M3.5.0,M10.5.0/3"; // https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
+
 const int RecordTime = 3;
 const int SensorPin = 5;
 float temperatur = 0;
@@ -82,13 +82,12 @@ void setup() {
   ArduinoOTA.begin();
   
   // Internet-Zeit holen
-  configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+  configTzTime(timeZone, ntpServer);
 
   //Server-Reaktionen definieren
   server.on("/init", getWebpage);
   server.on("/weather", getWeather);
   server.begin();
-
 }
 
 void loop() {


### PR DESCRIPTION
Hallo MAKE.

Ich habe heute euren Artikel gelesen und mir viel auf, dass die die Offsets manuell setzt. Es wäre besser die Timezone inklusive infos zur Zeitumstellung in der Firmware zu hinterlegen. Dann klappt es mit der Zeitumstellung automatisch und man muss nicht 2mal im Jahr die Firmware überschreiben. In [der List](https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv) findet man passend zur Zeitzone den entsprechenden Link.

Beste Grüße

René